### PR TITLE
Removed bash and dpkg-reconfigure dependencies from scripts

### DIFF
--- a/bin/exportcreds
+++ b/bin/exportcreds
@@ -1,10 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copies user and host credentials from "/etc" files and directories to the "/creds" volume.
 # This should be run whenever the source files change so they can be backed up.
 
+if [ -z "$EUID" ]; then
+  EUID="$(id -u)"
+fi
+
 # Must run as root.
-if [[ $EUID -ne 0 ]]; then
+if [ "$EUID" != "0" ]; then
    echo "This script must be run as root" 1>&2
    exit 1
 fi

--- a/bin/importcreds
+++ b/bin/importcreds
@@ -1,11 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copies user and host credentials from a mount to corresponding "/etc" files and directories.
 # This should be run once as root at container startup to import users and host keys from
 # external storage.
 
+if [ -z "$EUID" ]; then
+  EUID="$(id -u)"
+fi
+
 # Must run as root.
-if [[ $EUID -ne 0 ]]; then
+if [ "$EUID" != "0" ]; then
    echo "This script must be run as root" 1>&2
    exit 1
 fi

--- a/bin/sftpenv
+++ b/bin/sftpenv
@@ -1,9 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 # Set up required environment for SFTP.
 
+if [ -z "$EUID" ]; then
+  EUID="$(id -u)"
+fi
+
 # Must run as root.
-if [[ $EUID -ne 0 ]]; then
+if [ "$EUID" != "0" ]; then
    echo "This script must be run as root" 1>&2
    exit 1
 fi

--- a/bin/sftpenv
+++ b/bin/sftpenv
@@ -21,7 +21,7 @@ fi
 if [ ! -f "/etc/ssh/.containerkeys" ]; then
   echo "Creating new SSH host keys ..."
   rm /etc/ssh/ssh_host_*
-  dpkg-reconfigure openssh-server
+  ssh-keygen -A
   touch /etc/ssh/.containerkeys
 fi
 


### PR DESCRIPTION
My fork uses an alpine-based docker image which might, in the future, be merged into your main repository. To do so, it makes sense to remove certain, unnecessary dependencies.

- sh works fine assuming `root` user checking is done slightly differently
- `ssh-keygen -A` should be able to replace `dpkg-reconfigure openssh-server` be sure to test it yourself

Thanks for the useful image~!